### PR TITLE
Update git_repo_scanner helm chart version

### DIFF
--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -20,7 +20,7 @@ variable "NGINX_CHART_VERSION" {
 
 variable "METRICS_SERVER_VERSION" {
   type    = string
-  default = "3.8.2"
+  default = "3.12.1"
 }
 
 variable "CERTMANAGER_VERSION" {

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -25,7 +25,7 @@ variable "METRICS_SERVER_VERSION" {
 
 variable "CERTMANAGER_VERSION" {
   type    = string
-  default = "v1.10.0"
+  default = "v1.15.1"
 }
 
 variable "DATADOG_CRDS_VERSION" {

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -35,5 +35,5 @@ variable "DATADOG_CRDS_VERSION" {
 
 variable "DATADOG_VERSION" {
   type    = string
-  default = "3.1.11"
+  default = "3.68.2"
 }

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -15,7 +15,7 @@ variable "EFS_DRIVER_CHART_VERSION" {
 
 variable "NGINX_CHART_VERSION" {
   type    = string
-  default = "4.3.0"
+  default = "4.11.1"
 }
 
 variable "METRICS_SERVER_VERSION" {

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -10,7 +10,7 @@ variable "CLUSTER_AUTOSCALER_HELM_CHART_VERSION" {
 
 variable "EFS_DRIVER_CHART_VERSION" {
   type    = string
-  default = "2.2.9"
+  default = "3.0.6"
 }
 
 variable "NGINX_CHART_VERSION" {

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -30,7 +30,7 @@ variable "CERTMANAGER_VERSION" {
 
 variable "DATADOG_CRDS_VERSION" {
   type    = string
-  default = "0.4.7"
+  default = "1.7.0"
 }
 
 variable "DATADOG_VERSION" {

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -5,7 +5,7 @@ variable "AWS_LOAD_BALANCER_CONTROLLER_VERSION" {
 
 variable "CLUSTER_AUTOSCALER_HELM_CHART_VERSION" {
   type    = string
-  default = "9.21.0"
+  default = "9.37.0"
 }
 
 variable "EFS_DRIVER_CHART_VERSION" {

--- a/templates/eks/input.tf
+++ b/templates/eks/input.tf
@@ -1,6 +1,6 @@
 variable "AWS_LOAD_BALANCER_CONTROLLER_VERSION" {
   type    = string
-  default = "1.5.5"
+  default = "1.8.1"
 }
 
 variable "CLUSTER_AUTOSCALER_HELM_CHART_VERSION" {


### PR DESCRIPTION


Creating a pull request 1

---



<Actions>
    <action id="bbc22614ee6491f12e74b5d4714994f3bcb133c7621dae3eac42aee0659dae29">
        <h3>UPDATECLI.YAML</h3>
        <details id="de0d6a13ce09fde357d3c4c337d341b25cab1eacf8c480ef01c67e9cbbc2b042">
            <summary>Update cluster-autoscaler version in input.tf  latest version updated $&#34;&lt;no value&gt;&#34;</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.CLUSTER_AUTOSCALER_HELM_CHART_VERSION.default&#34; updated from &#34;9.21.0&#34; to &#34;9.37.0&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>9.37.0</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: cluster-autoscaler&#xA;Scales Kubernetes worker nodes within autoscaling groups.&#xA;Project Home: https://github.com/kubernetes/autoscaler&#xA;&#xA;Version created on the 2024-05-07 16:45:25.443647431 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/kubernetes/autoscaler/releases/download/cluster-autoscaler-chart-9.37.0/cluster-autoscaler-9.37.0.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="72f9aa9bc98f2c172dce6a9e7e870db2f82815725fafb752074c47f60c4b05c7">
            <summary>Update aws-efs-csi-driver version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.EFS_DRIVER_CHART_VERSION.default&#34; updated from &#34;2.2.9&#34; to &#34;3.0.6&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>3.0.6</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: aws-efs-csi-driver&#xA;A Helm chart for AWS EFS CSI Driver&#xA;Project Home: https://github.com/kubernetes-sigs/aws-efs-csi-driver&#xA;Require Kubernetes Version: &amp;gt;=1.17.0-0&#xA;Version created on the 2024-06-27 15:21:38.247058153 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kubernetes-sigs/aws-efs-csi-driver&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/download/helm-chart-aws-efs-csi-driver-3.0.6/aws-efs-csi-driver-3.0.6.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="f899bee112c5f1cc692d44d3898cd740e93f2d70f74ecdc5b9b7e5ddff525b8f">
            <summary>Update metrics-server version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.METRICS_SERVER_VERSION.default&#34; updated from &#34;3.8.2&#34; to &#34;3.12.1&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>3.12.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: metrics-server&#xA;Metrics Server is a scalable, efficient source of container resource metrics for Kubernetes built-in autoscaling pipelines.&#xA;Project Home: https://github.com/kubernetes-sigs/metrics-server&#xA;&#xA;Version created on the 2024-04-05 19:13:22.40760665 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kubernetes-sigs/metrics-server&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.12.1/metrics-server-3.12.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="7f8b1968e854d7afe9936a8f33469b579e52be4244cc6f251b29f5580eed81dd">
            <summary>Update ingress-nginx version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.NGINX_CHART_VERSION.default&#34; updated from &#34;4.3.0&#34; to &#34;4.11.1&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>4.11.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: ingress-nginx&#xA;Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer&#xA;Project Home: https://github.com/kubernetes/ingress-nginx&#xA;Require Kubernetes Version: &amp;gt;=1.21.0-0&#xA;Version created on the 2024-07-18 17:58:19.739924229 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kubernetes/ingress-nginx&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.11.1/ingress-nginx-4.11.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="cc8f4f42366d45f49f184dc64cf26811d3fd9370a386d13a593695d7485f7959">
            <summary>Update aws-load-balancer-controller version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.AWS_LOAD_BALANCER_CONTROLLER_VERSION.default&#34; updated from &#34;1.5.5&#34; to &#34;1.8.1&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>1.8.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: aws-load-balancer-controller&#xA;AWS Load Balancer Controller Helm chart for Kubernetes&#xA;Project Home: https://github.com/aws/eks-charts&#xA;&#xA;Version created on the 2024-07-12 17:57:28.477876715 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/aws/eks-charts&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://aws.github.io/eks-charts/aws-load-balancer-controller-1.8.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="37912c54d65ae07aed309c1c41d7d143f3b1fd9bba321a6d88bc5e9391794cf6">
            <summary>Update cert-manager version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.CERTMANAGER_VERSION.default&#34; updated from &#34;v1.10.0&#34; to &#34;v1.15.1&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>v1.15.1</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: cert-manager&#xA;A Helm chart for cert-manager&#xA;Project Home: https://cert-manager.io&#xA;Require Kubernetes Version: &amp;gt;= 1.22.0-0&#xA;Version created on the 2024-06-26 17:29:09.992842428 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/cert-manager/cert-manager&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* charts/cert-manager-v1.15.1.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="50fe98110cb9711e36eab18c4b03ec3f63f6253984651e38ad5f301df1c95d0f">
            <summary>Update datadog-crds version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.DATADOG_CRDS_VERSION.default&#34; updated from &#34;0.4.7&#34; to &#34;1.7.0&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>1.7.0</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: datadog-crds&#xA;Datadog Kubernetes CRDs chart&#xA;Project Home: https://www.datadoghq.com&#xA;&#xA;Version created on the 2024-06-17 14:43:05.67849553 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://app.datadoghq.com/account/settings#agent/kubernetes&#xA;&#xA;* https://github.com/DataDog/datadog-operator&#xA;&#xA;* https://docs.datadoghq.com/agent/cluster_agent/external_metrics&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/DataDog/helm-charts/releases/download/datadog-crds-1.7.0/datadog-crds-1.7.0.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="fde7a5818346da91064c6373540b16c6b752142257191d0d4054347c392e5786">
            <summary>Update datadog version in input.tf</summary>
            <p>changes detected:&#xA;&#x9;path &#34;variable.DATADOG_VERSION.default&#34; updated from &#34;3.1.11&#34; to &#34;3.68.2&#34; in file &#34;templates/eks/input.tf&#34;</p>
            <details>
                <summary>3.68.2</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: datadog&#xA;Datadog Agent&#xA;Project Home: https://www.datadoghq.com&#xA;&#xA;Version created on the 2024-07-21 05:47:37.504811044 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://app.datadoghq.com/account/settings#agent/kubernetes&#xA;&#xA;* https://github.com/DataDog/datadog-agent&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/DataDog/helm-charts/releases/download/datadog-3.68.2/datadog-3.68.2.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

